### PR TITLE
fix(husky): lintstaged git hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged


### PR DESCRIPTION
Fixed lintstaged not getting called on commits, given that its configuration was in the wrong subfolder.