### PR TITLE
ci(semantic-release): readded config for dependabot commit releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,13 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [{ "type": "chore", "release": "patch" }]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",


### PR DESCRIPTION
Dependabot creates chore pull requests for dependencies, it should notify semantic-release for patch updates.