### PR TITLE
ci(gh-pages-plugin): updated authentication workflow for gh-pages-plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
gh-pages-plugin uses git credentials for authentication, and this setup no longer is supported by github.

See: qiwi/semantic-release-gh-pages-plugin#181