### PR TITLE
fix(typings): included jsonapi-typescript declarations on prod installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4987,8 +4987,7 @@
     "json-typescript": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
-      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA==",
-      "dev": true
+      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA=="
     },
     "json5": {
       "version": "2.2.2",
@@ -5000,7 +4999,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/jsonapi-typescript/-/jsonapi-typescript-0.1.3.tgz",
       "integrity": "sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==",
-      "dev": true,
       "requires": {
         "json-typescript": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fetch-blob": "^3.2.0",
     "formdata-polyfill": "^4.0.10",
     "isomorphic-unfetch": "^3.1.0",
+    "jsonapi-typescript": "^0.1.3",
     "validator": "^13.7.0",
     "zod": "^3.20.2"
   },
@@ -70,7 +71,6 @@
     "jest": "^29.3.1",
     "jest-extended": "^3.2.0",
     "jest-fetch-mock": "^3.0.3",
-    "jsonapi-typescript": "^0.1.3",
     "lint-staged": "^13.1.0",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
jsonapi-typescript provides JSONAPI-Schema declarations, and it wasn't available on dist builds. moved from dev to prod deps, improving intellisense types.