### PR TITLE
ci(semantic-release): fixed chore commits on generated changelog

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,15 +11,9 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "angular",
+        "preset": "conventionalcommits",
         "presetConfig": {
-          "types": [
-            {
-              "type": "chore",
-              "section": "Chores",
-              "hidden": false
-            }
-          ]
+          "types": [{ "type": "chore", "section": "Chores", "hidden": false }]
         }
       }
     ],


### PR DESCRIPTION
release-notes-generator was using the wrong preset for generating commit messages, now it should add every chore type to the changelog.