### PR TITLE
ci(gh-pages): only run builds when semantic-release is completed

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,10 @@
 name: Github Pages
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ['Semantic Release']
+    types:
+      - completed
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Github pages builds were activated on every main branch commit, this change makes it run only when semantic-release is successfully executed.