### PR TITLE
ci(codecov): added codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Codecov uploader is breaking CI builds, the docs suggest manually adding the codecov token, even though it is not needed for public repos with GA.