### PR TITLE
ci(semantic-release): bumped minimum node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 18.x
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Semantic release builds broke on previous node version. The minimum is 18.x.