### PR TITLE
ci(auto-merge): updated token declaration

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
       - name: Checkout repo
@@ -17,3 +15,5 @@ jobs:
 
       - name: Run plugin
         uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.GA_TOKEN }}


### PR DESCRIPTION
auto-merge doesn't use the default github token environment variable, updated its declaration according to docs.