### PR TITLE
ci(auto-merge): updated auto-merge behavior for dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,4 +16,5 @@ jobs:
       - name: Run plugin
         uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
+          target: major
           github-token: ${{ secrets.GA_TOKEN }}


### PR DESCRIPTION
action-dependabot-auto-merge only runs on patch updates by default. This change makes it run on every dependency release (major/minor/patch).