### PR TITLE
ci: explicity added codedov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,4 @@ jobs:
         with:
           directory: ./coverage
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Builds are breaking on upload because of a codecov token error. Explicity added as recommended by the action maintainers.