### PR TITLE
test: removed oob enum range check

### DIFF
--- a/test/unit/schema.test.ts
+++ b/test/unit/schema.test.ts
@@ -142,14 +142,6 @@ describe('AbuseIPDBClient Unit Tests', () => {
         'Array must contain at most 30 element(s)',
       );
 
-      expect(client.report(validIP, [-1])).rejects.toThrow(
-        'Number must be greater than or equal to 1',
-      );
-
-      expect(client.report(validIP, [24])).rejects.toThrow(
-        'Number must be less than or equal to 23',
-      );
-
       expect(
         client.report(validIP, [1], { comment: Array(1025 + 1).toString() }),
       ).rejects.toThrow('String must contain at most 1024 character(s)');


### PR DESCRIPTION
Removed redundant enum test case given that TypeScript 5 now verify out-of-bound access by default. More info at: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#enum-overhaul