### PR TITLE
docs: updated typedoc replace-text plugin script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "npm run clean && rollup --config rollup.config.js",
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage",
     "lint": "prettier -w '{lib,test}/**/*.ts' && eslint --fix '{lib,test}/**/*.ts'",
-    "docs": "typedoc",
+    "docs": "typedoc --plugin typedoc-plugin-replace-text",
     "prepublishOnly": "npm run test && npm run build",
     "prepare": "is-ci || husky install",
     "semantic-release": "semantic-release"


### PR DESCRIPTION
Added typedoc-replace-text plugin declaration to npm script as it is required for Typedoc version 0.24.0+