### PR TITLE
ci(gh-pages): bumped gh-pages node version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 14.18.0
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 18.x
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Node v14.18.0 is breaking docs build, bumped to the same version used on the other workflows.