### PR TITLE
docs(typedoc): removed media folder reference

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,6 @@
   "name": "abuseipdb-client",
   "entryPoints": ["./lib/index.ts"],
   "out": "./docs",
-  "media": "./public",
   "includeVersion": true,
   "visibilityFilters": {
     "protected": false,


### PR DESCRIPTION
The `media` folder reference is no longer needed since v0.26.0 of the typedoc plugin