### PR TITLE
feat(api): updated duplicate ip report error handling

### DIFF
--- a/test/data/api.stub.ts
+++ b/test/data/api.stub.ts
@@ -28,7 +28,18 @@ const error = {
 const libraryResponseWrapper = (data: unknown) => ({
   headers,
   error: expect.toBeOneOf([expect.toBeNil(), error]),
-  result: expect.toBeOneOf([expect.toBeNil(), data]),
+  result: expect.toBeOneOf([
+    expect.toBeNil(),
+    data,
+    {
+      detail: expect.toBeOneOf([expect.toBeNil(), expect.any(String)]),
+      source: {
+        parameter: expect.any(String),
+        value: expect.any(String),
+      },
+      status: expect.any(Number),
+    },
+  ]),
 });
 
 // Endpoint responses:

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -211,15 +211,14 @@ describe('AbuseIPDBClient API Tests', () => {
       );
 
       expect(errorResponse).toMatchObject({
-        error: {
-          errors: [
-            {
-              detail:
-                'You can only report the same IP address (`127.0.0.2`) once in 15 minutes.',
-              source: { parameter: 'ip' },
-              status: 403,
-            },
-          ],
+        headers: {
+          status: 429,
+          statusText: 'Too Many Requests',
+        },
+        result: {
+          detail: 'You can only report the same IP address once in 15 minutes.',
+          source: { parameter: 'ip', value: '127.0.0.2' },
+          status: 429,
         },
       });
     });


### PR DESCRIPTION
BREAKING CHANGE: If you report duplicate IPs within a 15 minutes time frame, the response object sent by the API will be different. The result contains a detail/source/status definition, with the code 429, and the headers will also have a statusText as 'Too Many Requests'. There is a sample definition on the api test file.

fix #570 #568 #567 #566